### PR TITLE
Breaking Change: do one thing well

### DIFF
--- a/lua/neo-root.lua
+++ b/lua/neo-root.lua
@@ -9,7 +9,7 @@ BLUE_PILL = 2
 NEO_ZOOM_DID_INIT = false
 CUR_MODE = nil
 PROJ_ROOT = nil
-USER_ROOT = nil
+USER_ROOT = ''
 
 local M = {}
 
@@ -46,7 +46,7 @@ local function execute_mode_behaviour()
   if CUR_MODE == RED_PILL then
     vim.api.nvim_set_current_dir(vim.fn.expand('%:p:h'))
   else -- CUR_MODE == BLUE_PILL
-    if USER_ROOT ~= nil then
+    if USER_ROOT ~= '' then
       vim.api.nvim_set_current_dir(USER_ROOT)
     else
       vim.api.nvim_set_current_dir(PROJ_ROOT)
@@ -91,10 +91,10 @@ end
 
 function M.change_project_root()
   USER_ROOT = vim.fn.input('Set Project Root: ')
-  if USER_ROOT == nil then -- reset
-    vim.cmd('cd ' .. PROJ_ROOT)
-  else
+  if USER_ROOT ~= '' then -- reset
     vim.cmd('cd ' .. USER_ROOT)
+  else
+    vim.cmd('cd ' .. PROJ_ROOT)
   end
   apply_change()
 end

--- a/lua/neo-root.lua
+++ b/lua/neo-root.lua
@@ -37,9 +37,9 @@ local function level_up(total_level)
 end
 
 local function init()
-  CUR_MODE = BLUE_PILL
+  CUR_MODE = RED_PILL
   -- NOTE: Both `~`, `-`, `..` works with `vim.cmd`
-  PROJ_ROOT = print(vim.cmd('pwd')) -- might have bug
+  PROJ_ROOT = vim.fn.getcwd()
 end
 
 local function execute_mode_behaviour()
@@ -100,8 +100,8 @@ function M.change_project_root()
 end
 
 local function setup_vim_commands()
+  vim.cmd'au BufEnter * call v:lua.neo_root_execute()'
   vim.cmd [[
-    command! NeoRoot v:lua.neo_root_execute()
     command! NeoRootSwitchMode lua require('neo-root').change_mode()
     command! NeoRootChange lua require('neo-root').change_project_root()
   ]]

--- a/lua/neo-root.lua
+++ b/lua/neo-root.lua
@@ -55,7 +55,7 @@ local function execute_mode_behaviour()
 end
 
 local function apply_change()
-  M.execute()
+  _G.neo_root_execute()
   print(vim.cmd('pwd'))
 end
 ---------------------------------------------------------------------------------------------------
@@ -65,7 +65,7 @@ vim.api.nvim_set_keymap('n', '<Leader>prr', '<cmd>lua _G.reset_project_root(); _
 vim.api.nvim_set_keymap('n', '<Leader>pra',
 '<cmd>lua table.insert(_G.__PROJECT_ROOT, vim.fn.input("Extend Project Root: ")); _G.blue_pill_or_red_pill()<CR>', NOREF_NOERR_TRUNC)
 
-function M.execute()
+function _G.neo_root_execute()
   if not NEO_ZOOM_DID_INIT then
     init()
     NEO_ZOOM_DID_INIT = true
@@ -101,9 +101,9 @@ end
 
 local function setup_vim_commands()
   vim.cmd [[
-    command! NeoRoot lua require'neo-root'.execute()
-    command! NeoRootSwitchMode lua require'neo-root'.change_mode()
-    command! NeoRootChange lua require'neo-root'.change_project_root()
+    command! NeoRoot v:lua.neo_root_execute()
+    command! NeoRootSwitchMode lua require('neo-root').change_mode()
+    command! NeoRootChange lua require('neo-root').change_project_root()
   ]]
 end
 

--- a/plugin/neo-root.lua
+++ b/plugin/neo-root.lua
@@ -1,8 +1,8 @@
-if vim.fn.has("nvim-0.5") == 0 then
+if vim.fn.has("nvim-0.7") == 0 then
   return
 end
 
-if vim.g.loaded_neorooter_nvim ~= nil then
+if vim.g.loaded_neoroot_nvim ~= nil then
   return
 end
 
@@ -10,4 +10,4 @@ end
 
 require('neo-root')
 
-vim.g.loaded_neorooter_nvim = 1
+vim.g.loaded_neoroot_nvim = 1


### PR DESCRIPTION
resolve #2.

These are the behaviors after applying this PR:

- NeoRoot.lua will remember your project root **forever**.
- You can temporarily change your project root. E.g.:

    ```lua
    vim.keymap.set('n', '<Leader>pre', function() vim.cmd('NeoRootChange') end, NOREF_NOERR_TRUNC)
    ```
    - To change back to your project root, leave the prompt empty.
- You can toggle between: 1.(**_default_**) the directory of the current buffer 1. your (might be customized) project root. E.g.:

    ```lua
    vim.keymap.set('n', '<Leader>p', function() vim.cmd('NeoRootSwitchMode') end, NOREF_NOERR_TRUNC)
    ```